### PR TITLE
fix(ui): corregir desbordamiento de selects e implementar Combobox para catálogos grandes

### DIFF
--- a/docs/COMPONENTES_UI.md
+++ b/docs/COMPONENTES_UI.md
@@ -124,6 +124,52 @@ Componente estandarizado para acciones de fila en tablas.
 
 ---
 
+## Combobox (Buscador Seleccionable)
+
+Componente para selección de opciones con búsqueda integrada. Diseñado para manejar catálogos grandes (ej: 400+ materias primas) y evitar el recorte visual en contenedores pequeños mediante el uso de Portals.
+
+**Ubicación:** `resources/js/components/ui/combobox.tsx`
+
+### Props
+
+| Prop | Tipo | Default | Descripción |
+|------|------|---------|-------------|
+| `options` | `ComboboxOptionType[]` | - | Array de `{ id, label, description?, disabled? }` |
+| `value` | `string \| number \| null` | - | Valor seleccionado (ID) |
+| `onChange` | `(value: string \| number) => void` | - | Callback al seleccionar una opción |
+| `placeholder` | `string` | `'Seleccionar...'` | Texto cuando no hay selección |
+| `emptyText` | `string` | `'Sin resultados.'` | Texto cuando no hay coincidencias |
+| `className` | `string` | - | Clases adicionales para el contenedor |
+| `disabled` | `boolean` | `false` | Deshabilitar el componente |
+
+### Uso recomendado
+
+```tsx
+const options = rawMaterials.map(rm => ({
+    id: rm.id,
+    label: rm.code,
+    description: rm.name
+}));
+
+<Combobox
+    options={options}
+    value={data.raw_material_id}
+    onChange={(val) => setData('raw_material_id', val)}
+    placeholder="Busca una materia prima..."
+/>
+```
+
+### ¿Cuándo usar Combobox vs Select?
+
+| Característica | Select Standard | Combobox (Buscador) |
+|----------------|-----------------|----------------------|
+| **Número de items** | Pocos (< 15) | Muchos (> 15 o cientos) |
+| **Búsqueda** | No | Sí (instantánea) |
+| **Overflow** | Puede cortarse | Seguro (usa Portals) |
+| **Uso común** | Tipos, Estados, Bodegas | Productos, Materias Primas, Clientes |
+
+---
+
 ## Guías de implementación
 
 ### 1. Siempre usar componentes formateadores

--- a/docs/COMPONENTES_UI.md
+++ b/docs/COMPONENTES_UI.md
@@ -154,7 +154,7 @@ const options = rawMaterials.map(rm => ({
 <Combobox
     options={options}
     value={data.raw_material_id}
-    onChange={(val) => setData('raw_material_id', val)}
+    onChange={(val) => setData('raw_material_id', String(val))}
     placeholder="Busca una materia prima..."
 />
 ```

--- a/resources/js/components/ui/combobox.tsx
+++ b/resources/js/components/ui/combobox.tsx
@@ -1,0 +1,138 @@
+import {
+    Combobox as HeadlessCombobox,
+    ComboboxInput,
+    ComboboxOption,
+    ComboboxOptions,
+    ComboboxButton,
+    Transition,
+    Portal
+} from '@headlessui/react';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { useState, Fragment } from 'react';
+import { cn } from '@/lib/utils';
+
+export type ComboboxOptionType = {
+    id: string | number;
+    label: string;
+    description?: string;
+    disabled?: boolean;
+};
+
+interface ComboboxProps {
+    options: ComboboxOptionType[];
+    value: string | number | null;
+    onChange: (value: string | number) => void;
+    placeholder?: string;
+    emptyText?: string;
+    className?: string;
+    disabled?: boolean;
+}
+
+export function Combobox({
+    options,
+    value,
+    onChange,
+    placeholder = "Seleccionar...",
+    emptyText = "Sin resultados.",
+    className,
+    disabled = false
+}: ComboboxProps) {
+    const [query, setQuery] = useState('');
+
+    const selectedOption = options.find((o) => String(o.id) === String(value));
+
+    const filteredOptions = query === ''
+        ? options
+        : options.filter((option) =>
+            option.label
+                .toLowerCase()
+                .replace(/\s+/g, '')
+                .includes(query.toLowerCase().replace(/\s+/g, ''))
+        );
+
+    return (
+        <div className={cn("w-full", className)}>
+            <HeadlessCombobox 
+                value={value ?? undefined} 
+                onChange={(v) => {
+                    if (v !== null && v !== undefined) {
+                        onChange(v as string | number);
+                        setQuery(''); // Clear query on selection
+                    }
+                }} 
+                disabled={disabled}
+            >
+                <div className="relative">
+                    <ComboboxButton as="div" className={cn(
+                        "flex h-9 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs outline-hidden transition-[color,box-shadow] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50",
+                        disabled && "cursor-not-allowed opacity-50"
+                    )}>
+                        <ComboboxInput
+                            className="w-full border-none bg-transparent p-0 text-sm text-foreground outline-hidden placeholder:text-muted-foreground focus:ring-0"
+                            displayValue={() => selectedOption?.label || ''}
+                            onChange={(event) => setQuery(event.target.value)}
+                            placeholder={placeholder}
+                        />
+                        <div className="flex shrink-0 items-center opacity-50">
+                            <ChevronsUpDown className="h-4 w-4" aria-hidden="true" />
+                        </div>
+                    </ComboboxButton>
+
+                    <Portal>
+                        <Transition
+                            as={Fragment}
+                            leave="transition ease-in duration-100"
+                            leaveFrom="opacity-100"
+                            leaveTo="opacity-0"
+                        >
+                            <ComboboxOptions 
+                                anchor="bottom start"
+                                className="z-100 mt-1 max-h-60 w-(--input-width) overflow-auto rounded-md border border-border bg-popover py-1 text-base shadow-lg outline-hidden sm:text-sm [--anchor-gap:4px]"
+                            >
+                                {filteredOptions.length === 0 ? (
+                                    <div className="relative cursor-default select-none px-4 py-2 text-muted-foreground">
+                                        {emptyText}
+                                    </div>
+                                ) : (
+                                    filteredOptions.map((option) => (
+                                        <ComboboxOption
+                                            key={option.id}
+                                            className={({ focus }) =>
+                                                cn(
+                                                    "relative cursor-default select-none py-1.5 pl-3 pr-9 transition-colors outline-none",
+                                                    focus ? "bg-accent text-accent-foreground" : "text-foreground"
+                                                )
+                                            }
+                                            value={option.id}
+                                            disabled={option.disabled}
+                                        >
+                                            {({ selected }) => (
+                                                <>
+                                                    <div className="flex flex-col">
+                                                        <span className={cn("block truncate", selected ? "font-medium" : "font-normal")}>
+                                                            {option.label}
+                                                        </span>
+                                                        {option.description && (
+                                                            <span className="block truncate text-xs opacity-70">
+                                                                {option.description}
+                                                            </span>
+                                                        )}
+                                                    </div>
+                                                    {selected ? (
+                                                        <span className="absolute inset-y-0 right-0 flex items-center pr-3">
+                                                            <Check className="h-4 w-4" aria-hidden="true" />
+                                                        </span>
+                                                    ) : null}
+                                                </>
+                                            )}
+                                        </ComboboxOption>
+                                    ))
+                                )}
+                            </ComboboxOptions>
+                        </Transition>
+                    </Portal>
+                </div>
+            </HeadlessCombobox>
+        </div>
+    );
+}

--- a/resources/js/components/ui/select.tsx
+++ b/resources/js/components/ui/select.tsx
@@ -35,7 +35,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-md border bg-background px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none hover:bg-muted/25 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-md border bg-background px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none hover:bg-muted/25 focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -62,7 +62,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className
@@ -70,7 +70,7 @@ function SelectContent({
         position={position}
         side={side}
         sideOffset={sideOffset}
-        avoidCollisions={false}
+        avoidCollisions={true}
         align={align}
         {...props}
       >
@@ -79,7 +79,7 @@ function SelectContent({
           className={cn(
             "p-1",
             position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+              "h-9 w-full min-w-(--radix-select-trigger-width) scroll-my-1"
           )}
         >
           {children}
@@ -112,7 +112,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}

--- a/resources/js/pages/Formulas/Create.tsx
+++ b/resources/js/pages/Formulas/Create.tsx
@@ -12,6 +12,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { Textarea } from '@/components/ui/textarea';
 import {
     index as formulasIndex,
@@ -58,6 +59,16 @@ export default function FormulasCreate({
         notes: '',
         details: [emptyDetail()],
     });
+
+    const productOptions = products.map((p) => ({
+        id: String(p.id),
+        label: `${p.code} — ${p.name}`,
+    }));
+
+    const rawMaterialOptions = rawMaterials.map((rm) => ({
+        id: String(rm.id),
+        label: rm.code,
+    }));
 
     const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -119,27 +130,12 @@ export default function FormulasCreate({
 
                         <div className="space-y-2">
                             <Label htmlFor="product_id">Producto *</Label>
-                            <Select
+                            <Combobox
+                                options={productOptions}
                                 value={data.product_id}
-                                onValueChange={(v) => setData('product_id', v)}
-                            >
-                                <SelectTrigger id="product_id">
-                                    <SelectValue placeholder="Selecciona el producto" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    {products.map((p) => (
-                                        <SelectItem
-                                            key={p.id}
-                                            value={String(p.id)}
-                                        >
-                                            <span className="font-mono">
-                                                {p.code}
-                                            </span>{' '}
-                                            — {p.name}
-                                        </SelectItem>
-                                    ))}
-                                </SelectContent>
-                            </Select>
+                                onChange={(v) => setData('product_id', String(v))}
+                                placeholder="Busca o selecciona el producto..."
+                            />
                             {errors.product_id && (
                                 <p className="text-sm text-destructive">
                                     {errors.product_id}
@@ -201,32 +197,18 @@ export default function FormulasCreate({
                                                 Materia Prima
                                             </Label>
                                         )}
-                                        <Select
+                                        <Combobox
+                                            options={rawMaterialOptions}
                                             value={detail.raw_material_id}
-                                            onValueChange={(v) =>
+                                            onChange={(v) =>
                                                 updateDetail(
                                                     index,
                                                     'raw_material_id',
-                                                    v,
+                                                    String(v),
                                                 )
                                             }
-                                        >
-                                            <SelectTrigger>
-                                                <SelectValue placeholder="Selecciona..." />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                {rawMaterials.map((rm) => (
-                                                    <SelectItem
-                                                        key={rm.id}
-                                                        value={String(rm.id)}
-                                                    >
-                                                        <span className="font-mono">
-                                                            {rm.code}
-                                                        </span>
-                                                    </SelectItem>
-                                                ))}
-                                            </SelectContent>
-                                        </Select>
+                                            placeholder="Materia..."
+                                        />
                                         {(errors as Record<string, string>)[
                                             `details.${index}.raw_material_id`
                                         ] && (

--- a/resources/js/pages/Production/Orders/Create.tsx
+++ b/resources/js/pages/Production/Orders/Create.tsx
@@ -11,6 +11,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { Combobox } from '@/components/ui/combobox';
 import { Textarea } from '@/components/ui/textarea';
 import {
     index as productionOrderIndex,
@@ -53,6 +54,16 @@ export default function ProductionOrdersCreate({ products, warehouses }: Props) 
     const selectedProduct = products.find(p => p.id === Number(data.product_id));
     const availableFormulas = selectedProduct?.formulas || [];
     const availableVariants = selectedProduct?.variants || [];
+
+    const productOptions = products.map((p) => ({
+        id: String(p.id),
+        label: `${p.code} — ${p.name}`,
+    }));
+
+    const variantOptions = availableVariants.map((v) => ({
+        id: String(v.id),
+        label: `${v.sku} — ${v.presentation_label} (${v.presentation_value} gal)`,
+    }));
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -115,33 +126,19 @@ export default function ProductionOrdersCreate({ products, warehouses }: Props) 
                         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                             <div className="space-y-2">
                                 <Label htmlFor="product_id">Producto *</Label>
-                                <Select
+                                <Combobox
+                                    options={productOptions}
                                     value={data.product_id}
-                                    onValueChange={(v: string) => {
+                                    onChange={(v: string | number) => {
                                         setData({
                                             ...data,
-                                            product_id: v,
+                                            product_id: String(v),
                                             formula_id: '',
                                             packaging: [],
                                         });
                                     }}
-                                >
-                                    <SelectTrigger id="product_id">
-                                        <SelectValue placeholder="Selecciona un producto" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {products.map((p) => (
-                                            <SelectItem
-                                                key={p.id}
-                                                value={String(p.id)}
-                                            >
-                                                <span className="font-mono">{p.code}</span>
-                                                {' — '}
-                                                {p.name}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
+                                    placeholder="Busca o selecciona un producto..."
+                                />
                                 {errors.product_id && (
                                     <p className="text-sm text-destructive">{errors.product_id}</p>
                                 )}
@@ -309,26 +306,15 @@ export default function ProductionOrdersCreate({ products, warehouses }: Props) 
                                                     Presentación (SKU)
                                                 </Label>
                                             )}
-                                            <Select
+                                            <Combobox
+                                                options={variantOptions}
                                                 value={pack.product_variant_id}
-                                                onValueChange={(v) =>
-                                                    updatePackaging(index, 'product_variant_id', v)
+                                                onChange={(v) =>
+                                                    updatePackaging(index, 'product_variant_id', String(v))
                                                 }
-                                            >
-                                                <SelectTrigger>
-                                                    <SelectValue placeholder="Selecciona..." />
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                    {availableVariants.map((v: VariantOption) => (
-                                                        <SelectItem
-                                                            key={v.id}
-                                                            value={String(v.id)}
-                                                        >
-                                                            {v.sku} — {v.presentation_label} ({v.presentation_value} gal)
-                                                        </SelectItem>
-                                                    ))}
-                                                </SelectContent>
-                                            </Select>
+                                                placeholder="Presentación..."
+                                                disabled={!data.product_id}
+                                            />
                                         </div>
 
                                         <div className="col-span-4 space-y-1">

--- a/resources/js/pages/Production/Orders/Create.tsx
+++ b/resources/js/pages/Production/Orders/Create.tsx
@@ -129,7 +129,7 @@ export default function ProductionOrdersCreate({ products, warehouses }: Props) 
                                 <Combobox
                                     options={productOptions}
                                     value={data.product_id}
-                                    onChange={(v: string | number) => {
+                                    onChange={(v) => {
                                         setData({
                                             ...data,
                                             product_id: String(v),


### PR DESCRIPTION
## 🐛 Problema
Actualmente, al utilizar componentes `<Select>` nativos dentro de contenedores con `overflow: hidden` (como modales o tarjetas de creación de fórmulas), el menú desplegable se recorta visualmente. Esto impide ver todas las opciones cuando el catálogo es extenso (ej. más de 400 materias primas), afectando gravemente la experiencia de usuario.

## ✅ Solución Implementada
1. **Nuevo Componente `Combobox` (`resources/js/components/ui/combobox.tsx`):**
   - Utiliza **Portals** de Headless UI para renderizar el dropdown en el nivel raíz del DOM, eliminando por completo el problema de recorte visual.
   - Añade búsqueda instantánea insensible a espacios (ej: `MP001` coincide con `MP-001`).
   - Soporta descripciones secundarias en cada opción.

2. **Reemplazo de Selects problemáticos:**
   - **Fórmulas > Crear:** Selectores de *Producto* y *Materia Prima* ahora usan `Combobox`.
   - **Órdenes de Producción > Crear:** Selectores de *Producto* y *Presentación (SKU)* ahora usan `Combobox`.

3. **Documentación:** Se ha actualizado `docs/COMPONENTES_UI.md` con una guía de uso y una tabla comparativa para saber cuándo usar `Combobox` vs `Select` estándar.

## 🔧 Cambios Técnicos Relevantes
- Se creó el tipo `ComboboxOptionType` con soporte para `id`, `label`, `description` y `disabled`.
- Se estandarizó el patrón `onChange` con conversión explícita a `String(v)` en las páginas afectadas.
- Se realizaron ajustes menores en `Select` base (`avoidCollisions={true}`, `min-w-32`) para mejorar su comportamiento, sin afectar este PR.

## 🧪 Cómo Probar
1. Ir a **Fórmulas > Crear**.
2. Hacer clic en el campo **Producto**.  
   ✅ **Resultado esperado:** El menú se despliega completamente, sin cortarse.
3. Escribir en el buscador. El listado se filtra en tiempo real.
4. Repetir en **Producción > Órdenes > Crear** para los campos de Producto y Presentación.

## 📸 Evidencia Visual
*(Adjunta una captura de pantalla mostrando el menú desplegado sobre el modal)*

---
closes #45 