### PR TITLE
feat: update sales margin validation to max 99.99 and adjust calculations

### DIFF
--- a/app/Http/Controllers/Pricing/CostController.php
+++ b/app/Http/Controllers/Pricing/CostController.php
@@ -3,8 +3,9 @@
 namespace App\Http\Controllers\Pricing;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Pricing\UpdateCostRequest;
 use App\Models\Product;
-use App\Services\DecimalCalculator;
+use App\Services\VariantSalesPriceService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -13,7 +14,7 @@ use Inertia\Response;
 class CostController extends Controller
 {
     public function __construct(
-        private readonly DecimalCalculator $calculator,
+        private readonly VariantSalesPriceService $salesPriceService,
     ) {}
 
     /**
@@ -59,12 +60,11 @@ class CostController extends Controller
     /**
      * Update the sales margin for a product.
      */
-    public function update(Request $request, Product $product): RedirectResponse
+    public function update(UpdateCostRequest $request, Product $product): RedirectResponse
     {
-        $validated = $request->validate([
-            'sales_margin' => ['nullable', 'numeric', 'min:0', 'max:99.99'],
-            'sales_price' => ['nullable', 'numeric', 'gt:0'],
-        ]);
+        $this->authorize('update', $product);
+
+        $validated = $request->validated();
 
         $salesMargin = $validated['sales_margin'] ?? null;
 
@@ -75,13 +75,10 @@ class CostController extends Controller
                 ]);
             }
 
-            $ratio = $this->calculator->div(
-                (string) $product->current_price,
-                (string) $validated['sales_price'],
-                6,
+            $salesMargin = (float) $this->salesPriceService->resolveMarginFromSalesPrice(
+                $product->current_price,
+                $validated['sales_price'],
             );
-            $marginDecimal = $this->calculator->sub('1', $ratio, 6);
-            $salesMargin = (float) $this->calculator->mul($marginDecimal, '100', 2);
         }
 
         if ($salesMargin !== null && ($salesMargin < 0 || $salesMargin >= 100)) {

--- a/app/Http/Controllers/Pricing/CostController.php
+++ b/app/Http/Controllers/Pricing/CostController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Pricing;
 
 use App\Http\Controllers\Controller;
 use App\Models\Product;
+use App\Services\DecimalCalculator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -11,6 +12,10 @@ use Inertia\Response;
 
 class CostController extends Controller
 {
+    public function __construct(
+        private readonly DecimalCalculator $calculator,
+    ) {}
+
     /**
      * Display the costs dashboard for admin.
      */
@@ -57,8 +62,8 @@ class CostController extends Controller
     public function update(Request $request, Product $product): RedirectResponse
     {
         $validated = $request->validate([
-            'sales_margin' => ['nullable', 'numeric', 'min:0', 'max:500'],
-            'sales_price' => ['nullable', 'numeric', 'min:0'],
+            'sales_margin' => ['nullable', 'numeric', 'min:0', 'max:99.99'],
+            'sales_price' => ['nullable', 'numeric', 'gt:0'],
         ]);
 
         $salesMargin = $validated['sales_margin'] ?? null;
@@ -70,12 +75,18 @@ class CostController extends Controller
                 ]);
             }
 
-            $salesMargin = round((($validated['sales_price'] / $product->current_price) - 1) * 100, 2);
+            $ratio = $this->calculator->div(
+                (string) $product->current_price,
+                (string) $validated['sales_price'],
+                6,
+            );
+            $marginDecimal = $this->calculator->sub('1', $ratio, 6);
+            $salesMargin = (float) $this->calculator->mul($marginDecimal, '100', 2);
         }
 
-        if ($salesMargin !== null && ($salesMargin < 0 || $salesMargin > 500)) {
+        if ($salesMargin !== null && ($salesMargin < 0 || $salesMargin >= 100)) {
             return back()->withErrors([
-                'sales_price' => 'El precio ingresado genera un margen inválido (debe estar entre 0% y 500%).',
+                'sales_price' => 'El precio ingresado genera un margen inválido (debe estar entre 0% y 99.99%).',
             ]);
         }
 

--- a/app/Http/Requests/Pricing/UpdateCostRequest.php
+++ b/app/Http/Requests/Pricing/UpdateCostRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Pricing;
+
+use App\Models\Product;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        /** @var Product|null $product */
+        $product = $this->route('product');
+
+        return $this->user()?->can('update', $product) ?? false;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'sales_margin' => ['nullable', 'numeric', 'min:0', 'max:99.99'],
+            'sales_price' => ['nullable', 'numeric', 'gt:0'],
+        ];
+    }
+}

--- a/app/Services/VariantSalesPriceService.php
+++ b/app/Services/VariantSalesPriceService.php
@@ -39,12 +39,16 @@ class VariantSalesPriceService
         );
     }
 
-    public function applySalesMargin(string $basePrice, float|string|null $salesMargin): string
+    public function applySalesMargin(string $basePrice, float|string|null $salesMargin): ?string
     {
         $margin = $salesMargin !== null ? (string) $salesMargin : '0';
         $marginDecimal = $this->calculator->div($margin, '100', 4);
-        $multiplier = $this->calculator->add('1', $marginDecimal, 4);
+        $divisor = $this->calculator->sub('1', $marginDecimal, 4);
 
-        return $this->calculator->mul($basePrice, $multiplier, 4);
+        if ($this->calculator->cmp($divisor, '0', 4) <= 0) {
+            return null;
+        }
+
+        return $this->calculator->div($basePrice, $divisor, 4);
     }
 }

--- a/app/Services/VariantSalesPriceService.php
+++ b/app/Services/VariantSalesPriceService.php
@@ -20,7 +20,7 @@ class VariantSalesPriceService
         }
 
         return $this->applySalesMargin(
-            (string) $product->current_price,
+            $this->toDecimalString($product->current_price, 4),
             $product->sales_margin
         );
     }
@@ -34,13 +34,14 @@ class VariantSalesPriceService
         $variant->loadMissing('product:id,sales_margin');
 
         return $this->applySalesMargin(
-            (string) $variant->current_price,
+            $this->toDecimalString($variant->current_price, 4),
             $variant->product?->sales_margin
         );
     }
 
-    public function applySalesMargin(string $basePrice, float|string|null $salesMargin): ?string
+    public function applySalesMargin(string|float $basePrice, float|string|null $salesMargin): ?string
     {
+        $base = $this->toDecimalString($basePrice, 4);
         $margin = $salesMargin !== null ? (string) $salesMargin : '0';
         $marginDecimal = $this->calculator->div($margin, '100', 4);
         $divisor = $this->calculator->sub('1', $marginDecimal, 4);
@@ -49,6 +50,22 @@ class VariantSalesPriceService
             return null;
         }
 
-        return $this->calculator->div($basePrice, $divisor, 4);
+        return $this->calculator->div($base, $divisor, 4);
+    }
+
+    public function resolveMarginFromSalesPrice(string|float $basePrice, string|float $salesPrice): string
+    {
+        $base = $this->toDecimalString($basePrice, 6);
+        $sale = $this->toDecimalString($salesPrice, 6);
+
+        $ratio = $this->calculator->div($base, $sale, 6);
+        $marginDecimal = $this->calculator->sub('1', $ratio, 6);
+
+        return $this->calculator->mul($marginDecimal, '100', 2);
+    }
+
+    private function toDecimalString(string|float $value, int $scale = 4): string
+    {
+        return is_string($value) ? $value : number_format((float) $value, $scale, '.', '');
     }
 }

--- a/resources/js/pages/Costs/Index.tsx
+++ b/resources/js/pages/Costs/Index.tsx
@@ -50,12 +50,21 @@ function calculateSalesPrice(
     }
 
     const margin = salesMargin ?? 0;
+    const divisor = 1 - margin / 100;
 
-    return parseFloat((currentPrice * (1 + margin / 100)).toFixed(2));
+    if (divisor <= 0) {
+        return null;
+    }
+
+    return parseFloat((currentPrice / divisor).toFixed(2));
 }
 
-function calculateMargin(currentPrice: number, salesPrice: number): number {
-    return parseFloat(((salesPrice / currentPrice - 1) * 100).toFixed(2));
+function calculateMargin(currentPrice: number, salesPrice: number): number | null {
+    if (salesPrice <= 0) {
+        return null;
+    }
+
+    return parseFloat(((1 - currentPrice / salesPrice) * 100).toFixed(2));
 }
 
 function buildInitialMargins(
@@ -302,6 +311,17 @@ export default function CostsIndex({
             }
 
             const price = parseFloat(priceValue) || 0;
+
+            if (price <= 0) {
+                dispatch({
+                    type: 'SET_ERROR',
+                    productId,
+                    error: 'El precio de venta debe ser mayor a 0.',
+                });
+
+                return;
+            }
+
             const margin =
                 priceValue === ''
                     ? ''
@@ -347,11 +367,11 @@ export default function CostsIndex({
                     return;
                 }
 
-                if (numericValue < 0 || numericValue > 500) {
+                if (numericValue < 0 || numericValue >= 100) {
                     dispatch({
                         type: 'SET_ERROR',
                         productId,
-                        error: 'El margen debe estar entre 0% y 500%.',
+                        error: 'El margen debe estar entre 0% y 99.99%.',
                     });
 
                     return;
@@ -499,7 +519,7 @@ export default function CostsIndex({
                                         Precio Interno
                                     </th>
                                     <th className="p-4 text-right font-medium">
-                                        Margen Venta %
+                                        Margen Venta % (s/ venta)
                                     </th>
                                     <th className="p-4 text-right font-medium">
                                         Precio Venta
@@ -578,7 +598,7 @@ export default function CostsIndex({
                                                                 <Input
                                                                     type="number"
                                                                     min={0}
-                                                                    max={500}
+                                                                    max={99.99}
                                                                     step={0.01}
                                                                     value={
                                                                         state.margin

--- a/resources/js/pages/Prices/Index.tsx
+++ b/resources/js/pages/Prices/Index.tsx
@@ -141,14 +141,14 @@ export default function PricesIndex({
                                                     />
                                                 </span>
                                                 <span>
-                                                    Margen:{' '}
+                                                    Margen Venta:{' '}
                                                     <FormattedNumber
                                                         value={
                                                             product.sales_margin
                                                         }
                                                         maxDecimals={2}
                                                     />
-                                                    %
+                                                    % (s/ venta)
                                                 </span>
                                             </div>
                                         )}

--- a/tests/Feature/Pricing/CostControllerTest.php
+++ b/tests/Feature/Pricing/CostControllerTest.php
@@ -149,10 +149,10 @@ describe('update', function () {
             ->assertSessionHasErrors('sales_margin');
     });
 
-    it('validates sales_margin maximum is 500', function () {
+    it('validates sales_margin maximum is 99.99', function () {
         $this->actingAs($this->adminUser)
             ->patch(route('admin.costs.update', $this->product), [
-                'sales_margin' => 501,
+                'sales_margin' => 100,
             ])
             ->assertSessionHasErrors('sales_margin');
     });
@@ -167,7 +167,7 @@ describe('update', function () {
 
         $this->assertDatabaseHas('products', [
             'id' => $this->product->id,
-            'sales_margin' => '25.00',
+            'sales_margin' => '20.00',
         ]);
     });
 
@@ -191,30 +191,30 @@ describe('update', function () {
             ->assertSessionHasErrors('sales_price');
     });
 
-    it('allows sales_margin up to 500', function () {
+    it('rejects sales_price of zero', function () {
         $this->actingAs($this->adminUser)
             ->patch(route('admin.costs.update', $this->product), [
-                'sales_margin' => 500.00,
-            ])
-            ->assertRedirect()
-            ->assertSessionHas('success');
-
-        $this->assertDatabaseHas('products', [
-            'id' => $this->product->id,
-            'sales_margin' => '500.00',
-        ]);
-    });
-
-    it('rejects sales_price that generates margin over 500', function () {
-        $this->actingAs($this->adminUser)
-            ->patch(route('admin.costs.update', $this->product), [
-                'sales_price' => 1000.00,
+                'sales_price' => 0,
             ])
             ->assertSessionHasErrors('sales_price');
 
         $this->assertDatabaseHas('products', [
             'id' => $this->product->id,
             'sales_margin' => null,
+        ]);
+    });
+
+    it('allows sales_margin up to 99.99', function () {
+        $this->actingAs($this->adminUser)
+            ->patch(route('admin.costs.update', $this->product), [
+                'sales_margin' => 99.99,
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        $this->assertDatabaseHas('products', [
+            'id' => $this->product->id,
+            'sales_margin' => '99.99',
         ]);
     });
 

--- a/tests/Feature/Pricing/PriceListControllerTest.php
+++ b/tests/Feature/Pricing/PriceListControllerTest.php
@@ -92,11 +92,11 @@ it('allows admin to view price list with variants and sales prices', function ()
             ->where('products.data.0.id', $this->product->id)
             ->where('products.data.0.name', 'Producto Test')
             ->where('products.data.0.sales_margin', '25.00')
-            ->where('products.data.0.sales_price', 115)
+            ->where('products.data.0.sales_price', 122.6667)
             ->has('products.data.0.variants', 1)
             ->where('products.data.0.variants.0.id', $this->variant->id)
             ->where('products.data.0.variants.0.name', 'Cubeta 5 Galones')
-            ->where('products.data.0.variants.0.sales_price', 575)
+            ->where('products.data.0.variants.0.sales_price', 613.3333)
             ->where('can.view_costs', true)
             ->where('can.view_prices', true)
         );
@@ -112,9 +112,9 @@ it('allows comercial to view price list without cost data', function () {
             ->where('can.view_costs', false)
             ->where('can.view_prices', true)
             ->where('products.data.0.id', $this->product->id)
-            ->where('products.data.0.sales_price', 115)
+            ->where('products.data.0.sales_price', 122.6667)
             ->has('products.data.0.variants', 1)
-            ->where('products.data.0.variants.0.sales_price', 575)
+            ->where('products.data.0.variants.0.sales_price', 613.3333)
         );
 });
 

--- a/tests/Feature/Products/ProductSalesMarginTest.php
+++ b/tests/Feature/Products/ProductSalesMarginTest.php
@@ -70,16 +70,16 @@ it('accepts zero as sales_margin', function () {
     expect((float) $product->sales_margin)->toBe(0.0);
 });
 
-it('accepts maximum sales_margin of 500', function () {
+it('accepts maximum valid sales_margin of 99.99', function () {
     $product = Product::create([
         'code' => 'PROD-004',
         'name' => 'Producto Margen Max',
         'brand' => 'BEPRO',
         'category_id' => $this->category->id,
         'unit_of_measure_id' => $this->unit->id,
-        'sales_margin' => 500.00,
+        'sales_margin' => 99.99,
         'is_active' => true,
     ]);
 
-    expect((float) $product->sales_margin)->toBe(500.00);
+    expect((float) $product->sales_margin)->toBe(99.99);
 });

--- a/tests/Feature/Quotations/QuotationsTest.php
+++ b/tests/Feature/Quotations/QuotationsTest.php
@@ -249,7 +249,7 @@ it('renders quotation pdf template with bepro layout sections', function () {
 it('uses shared sales price service for list prices', function () {
     $service = app(VariantSalesPriceService::class);
 
-    expect((float) $service->resolveForVariant($this->variant))->toEqual(83990.0);
+    expect((float) $service->resolveForVariant($this->variant))->toEqual(89589.3333);
 });
 
 it('validates quotation update requires draft status', function () {

--- a/tests/Unit/VariantSalesPriceServiceTest.php
+++ b/tests/Unit/VariantSalesPriceServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\VariantSalesPriceService;
+
+beforeEach(function () {
+    $this->service = app(VariantSalesPriceService::class);
+});
+
+test('it calculates margin from base and sales price', function () {
+    expect($this->service->resolveMarginFromSalesPrice('92', '115'))->toBe('20.00');
+    expect($this->service->resolveMarginFromSalesPrice(92.0, 115.0))->toBe('20.00');
+});
+
+test('it returns zero margin when prices are equal', function () {
+    expect($this->service->resolveMarginFromSalesPrice('100', '100'))->toBe('0.00');
+});
+
+test('it normalizes floats without scientific notation', function () {
+    expect($this->service->resolveMarginFromSalesPrice(0.0001, 0.0002))->toBe('50.00');
+});
+
+test('applySalesMargin and resolveMarginFromSalesPrice are inverses', function () {
+    $price = $this->service->applySalesMargin('92', 20.0);
+    $margin = $this->service->resolveMarginFromSalesPrice('92', $price);
+
+    expect((float) $margin)->toBe(20.0);
+});
+
+test('resolveForProduct normalizes float current_price safely', function () {
+    // This test ensures float-to-string normalization does not break existing behavior.
+    // Using a float that could otherwise lose precision or become scientific notation.
+    $price = $this->service->applySalesMargin(92.0, 20.0);
+
+    expect($price)->toBe('115.0000');
+});


### PR DESCRIPTION
## Descripción
Cambia el cálculo del margen de ventas de markup-sobre-costo a margen-sobre-venta: precio = costo / (1 - margen/100). Se unifican los límites de validación a 99.99 en backend y frontend, y se protege contra división por cero en sales_price.

## Cambios principales
- **CostController**: validación de margen max 99.99, rango inicial, guard de división por cero (gt:0 en sales_price).
- **VariantSalesPriceService**: nueva fórmula de margen sobre venta.
- **Frontend** (Costs/Index, Prices/Index): fórmulas y etiquetas actualizadas.

## Riesgos a revisar
- Márgenes heredados >= 100 en BD se traducirán a sales_price nulo. Considerar verificar/normalizar datos antes del despliegue.